### PR TITLE
Add .travis.yml, fix go vet with ragel file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: go
+sudo: true
+
+go:
+  - "1.11.x"
+  - "tip"
+
+env:
+  - GO111MODULE=on
+
+before_script:
+  - sudo apt-get install -y libpcap-dev
+
+matrix:
+  allow_failures:
+    - go: tip
+
+script:
+  - make test
+  - make
+  - find example/pcap -name "*.pcap" \( -exec echo -e "\n Running {} \n" \; -exec ./heplify -rf {} -rs -e -hs "" \; -o -quit \)

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,16 @@
 NAME?=heplify
 
+PKGLIST=$(shell go list ./... | grep -Ev '/vendor|decoder/internal')
+
 all:
 	go build -ldflags "-s -w"  -o $(NAME) *.go
 
 debug:
 	go build -o $(NAME) *.go
+
+test:
+	go vet $(PKGLIST)
+	go test $(PKGLIST)
 
 .PHONY: clean
 clean:

--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -12,11 +12,12 @@ import (
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/tcpassembly"
+	"github.com/negbie/logp"
 	"github.com/sipcapture/heplify/config"
+	"github.com/sipcapture/heplify/decoder/internal"
 	"github.com/sipcapture/heplify/ip4defrag"
 	"github.com/sipcapture/heplify/ip6defrag"
 	"github.com/sipcapture/heplify/protos"
-	"github.com/negbie/logp"
 )
 
 type Decoder struct {
@@ -161,7 +162,7 @@ func (d *Decoder) Process(data []byte, ci *gopacket.CaptureInfo) {
 	}
 
 	if config.Cfg.DiscardMethod != "" {
-		c := parseCSeq(data)
+		c := internal.ParseCSeq(data)
 		if c != nil {
 			for _, v := range d.filter {
 				if string(c) == v {

--- a/decoder/internal/machine.go
+++ b/decoder/internal/machine.go
@@ -1,7 +1,5 @@
-
 //line machine.rl:1
-package decoder
-
+package internal
 
 //line machine.go:7
 const decoder_start int = 1
@@ -10,172 +8,169 @@ const decoder_error int = 0
 
 const decoder_en_main int = 1
 
-
 //line machine.rl:6
 
-
-func parseCSeq(data []byte) (c []byte) {
+func ParseCSeq(data []byte) (c []byte) {
 	cs, p, pe := 0, 0, len(data)
 	mark := 0
 
-	
 //line machine.go:23
 	{
-	cs = decoder_start
+		cs = decoder_start
 	}
 
 //line machine.go:28
 	{
-	if p == pe {
-		goto _test_eof
-	}
-	switch cs {
-	case 1:
-		goto st_case_1
-	case 2:
-		goto st_case_2
-	case 3:
-		goto st_case_3
-	case 4:
-		goto st_case_4
-	case 5:
-		goto st_case_5
-	case 6:
-		goto st_case_6
-	case 7:
-		goto st_case_7
-	case 8:
-		goto st_case_8
-	case 9:
-		goto st_case_9
-	case 10:
-		goto st_case_10
-	case 11:
-		goto st_case_11
-	case 12:
-		goto st_case_12
-	case 13:
-		goto st_case_13
-	case 14:
-		goto st_case_14
-	case 15:
-		goto st_case_15
-	case 16:
-		goto st_case_16
-	case 17:
-		goto st_case_17
-	case 18:
-		goto st_case_18
-	case 0:
-		goto st_case_0
-	case 71:
-		goto st_case_71
-	case 19:
-		goto st_case_19
-	case 20:
-		goto st_case_20
-	case 21:
-		goto st_case_21
-	case 22:
-		goto st_case_22
-	case 23:
-		goto st_case_23
-	case 24:
-		goto st_case_24
-	case 25:
-		goto st_case_25
-	case 26:
-		goto st_case_26
-	case 27:
-		goto st_case_27
-	case 28:
-		goto st_case_28
-	case 29:
-		goto st_case_29
-	case 30:
-		goto st_case_30
-	case 31:
-		goto st_case_31
-	case 32:
-		goto st_case_32
-	case 33:
-		goto st_case_33
-	case 34:
-		goto st_case_34
-	case 35:
-		goto st_case_35
-	case 36:
-		goto st_case_36
-	case 37:
-		goto st_case_37
-	case 38:
-		goto st_case_38
-	case 39:
-		goto st_case_39
-	case 40:
-		goto st_case_40
-	case 41:
-		goto st_case_41
-	case 42:
-		goto st_case_42
-	case 43:
-		goto st_case_43
-	case 44:
-		goto st_case_44
-	case 45:
-		goto st_case_45
-	case 46:
-		goto st_case_46
-	case 47:
-		goto st_case_47
-	case 48:
-		goto st_case_48
-	case 49:
-		goto st_case_49
-	case 50:
-		goto st_case_50
-	case 51:
-		goto st_case_51
-	case 52:
-		goto st_case_52
-	case 53:
-		goto st_case_53
-	case 54:
-		goto st_case_54
-	case 55:
-		goto st_case_55
-	case 56:
-		goto st_case_56
-	case 57:
-		goto st_case_57
-	case 58:
-		goto st_case_58
-	case 59:
-		goto st_case_59
-	case 60:
-		goto st_case_60
-	case 61:
-		goto st_case_61
-	case 62:
-		goto st_case_62
-	case 63:
-		goto st_case_63
-	case 64:
-		goto st_case_64
-	case 65:
-		goto st_case_65
-	case 66:
-		goto st_case_66
-	case 67:
-		goto st_case_67
-	case 68:
-		goto st_case_68
-	case 69:
-		goto st_case_69
-	case 70:
-		goto st_case_70
-	}
-	goto st_out
+		if p == pe {
+			goto _test_eof
+		}
+		switch cs {
+		case 1:
+			goto st_case_1
+		case 2:
+			goto st_case_2
+		case 3:
+			goto st_case_3
+		case 4:
+			goto st_case_4
+		case 5:
+			goto st_case_5
+		case 6:
+			goto st_case_6
+		case 7:
+			goto st_case_7
+		case 8:
+			goto st_case_8
+		case 9:
+			goto st_case_9
+		case 10:
+			goto st_case_10
+		case 11:
+			goto st_case_11
+		case 12:
+			goto st_case_12
+		case 13:
+			goto st_case_13
+		case 14:
+			goto st_case_14
+		case 15:
+			goto st_case_15
+		case 16:
+			goto st_case_16
+		case 17:
+			goto st_case_17
+		case 18:
+			goto st_case_18
+		case 0:
+			goto st_case_0
+		case 71:
+			goto st_case_71
+		case 19:
+			goto st_case_19
+		case 20:
+			goto st_case_20
+		case 21:
+			goto st_case_21
+		case 22:
+			goto st_case_22
+		case 23:
+			goto st_case_23
+		case 24:
+			goto st_case_24
+		case 25:
+			goto st_case_25
+		case 26:
+			goto st_case_26
+		case 27:
+			goto st_case_27
+		case 28:
+			goto st_case_28
+		case 29:
+			goto st_case_29
+		case 30:
+			goto st_case_30
+		case 31:
+			goto st_case_31
+		case 32:
+			goto st_case_32
+		case 33:
+			goto st_case_33
+		case 34:
+			goto st_case_34
+		case 35:
+			goto st_case_35
+		case 36:
+			goto st_case_36
+		case 37:
+			goto st_case_37
+		case 38:
+			goto st_case_38
+		case 39:
+			goto st_case_39
+		case 40:
+			goto st_case_40
+		case 41:
+			goto st_case_41
+		case 42:
+			goto st_case_42
+		case 43:
+			goto st_case_43
+		case 44:
+			goto st_case_44
+		case 45:
+			goto st_case_45
+		case 46:
+			goto st_case_46
+		case 47:
+			goto st_case_47
+		case 48:
+			goto st_case_48
+		case 49:
+			goto st_case_49
+		case 50:
+			goto st_case_50
+		case 51:
+			goto st_case_51
+		case 52:
+			goto st_case_52
+		case 53:
+			goto st_case_53
+		case 54:
+			goto st_case_54
+		case 55:
+			goto st_case_55
+		case 56:
+			goto st_case_56
+		case 57:
+			goto st_case_57
+		case 58:
+			goto st_case_58
+		case 59:
+			goto st_case_59
+		case 60:
+			goto st_case_60
+		case 61:
+			goto st_case_61
+		case 62:
+			goto st_case_62
+		case 63:
+			goto st_case_63
+		case 64:
+			goto st_case_64
+		case 65:
+			goto st_case_65
+		case 66:
+			goto st_case_66
+		case 67:
+			goto st_case_67
+		case 68:
+			goto st_case_68
+		case 69:
+			goto st_case_69
+		case 70:
+			goto st_case_70
+		}
+		goto st_out
 	st1:
 		if p++; p == pe {
 			goto _test_eof1
@@ -449,12 +444,12 @@ func parseCSeq(data []byte) (c []byte) {
 			goto st2
 		}
 		goto st1
-tr12:
+	tr12:
 //line machine.rl:40
 
-			mark = p
-		
-	goto st15
+		mark = p
+
+		goto st15
 	st15:
 		if p++; p == pe {
 			goto _test_eof15
@@ -500,12 +495,12 @@ tr12:
 			goto st2
 		}
 		goto st1
-tr27:
+	tr27:
 //line machine.rl:44
 
-			c=data[mark:p]
-		
-	goto st18
+		c = data[mark:p]
+
+		goto st18
 	st18:
 		if p++; p == pe {
 			goto _test_eof18
@@ -516,14 +511,14 @@ tr27:
 			goto tr28
 		}
 		goto st0
-st_case_0:
+	st_case_0:
 	st0:
 		cs = 0
 		goto _out
-tr28:
+	tr28:
 //line machine.rl:49
- return c 
-	goto st71
+		return c
+		goto st71
 	st71:
 		if p++; p == pe {
 			goto _test_eof71
@@ -531,12 +526,12 @@ tr28:
 	st_case_71:
 //line machine.go:533
 		goto st0
-tr13:
+	tr13:
 //line machine.rl:40
 
-			mark = p
-		
-	goto st19
+		mark = p
+
+		goto st19
 	st19:
 		if p++; p == pe {
 			goto _test_eof19
@@ -566,12 +561,12 @@ tr13:
 			goto st2
 		}
 		goto st1
-tr14:
+	tr14:
 //line machine.rl:40
 
-			mark = p
-		
-	goto st21
+		mark = p
+
+		goto st21
 	st21:
 		if p++; p == pe {
 			goto _test_eof21
@@ -649,12 +644,12 @@ tr14:
 			goto st2
 		}
 		goto st1
-tr15:
+	tr15:
 //line machine.rl:40
 
-			mark = p
-		
-	goto st26
+		mark = p
+
+		goto st26
 	st26:
 		if p++; p == pe {
 			goto _test_eof26
@@ -728,12 +723,12 @@ tr15:
 			goto st2
 		}
 		goto st1
-tr16:
+	tr16:
 //line machine.rl:40
 
-			mark = p
-		
-	goto st31
+		mark = p
+
+		goto st31
 	st31:
 		if p++; p == pe {
 			goto _test_eof31
@@ -805,12 +800,12 @@ tr16:
 			goto st2
 		}
 		goto st1
-tr17:
+	tr17:
 //line machine.rl:40
 
-			mark = p
-		
-	goto st36
+		mark = p
+
+		goto st36
 	st36:
 		if p++; p == pe {
 			goto _test_eof36
@@ -882,12 +877,12 @@ tr17:
 			goto st2
 		}
 		goto st1
-tr18:
+	tr18:
 //line machine.rl:40
 
-			mark = p
-		
-	goto st41
+		mark = p
+
+		goto st41
 	st41:
 		if p++; p == pe {
 			goto _test_eof41
@@ -973,12 +968,12 @@ tr18:
 			goto st2
 		}
 		goto st1
-tr19:
+	tr19:
 //line machine.rl:40
 
-			mark = p
-		
-	goto st47
+		mark = p
+
+		goto st47
 	st47:
 		if p++; p == pe {
 			goto _test_eof47
@@ -1080,12 +1075,12 @@ tr19:
 			goto st2
 		}
 		goto st1
-tr20:
+	tr20:
 //line machine.rl:40
 
-			mark = p
-		
-	goto st54
+		mark = p
+
+		goto st54
 	st54:
 		if p++; p == pe {
 			goto _test_eof54
@@ -1187,12 +1182,12 @@ tr20:
 			goto st2
 		}
 		goto st1
-tr21:
+	tr21:
 //line machine.rl:40
 
-			mark = p
-		
-	goto st61
+		mark = p
+
+		goto st61
 	st61:
 		if p++; p == pe {
 			goto _test_eof61
@@ -1294,12 +1289,12 @@ tr21:
 			goto st2
 		}
 		goto st1
-tr22:
+	tr22:
 //line machine.rl:40
 
-			mark = p
-		
-	goto st68
+		mark = p
+
+		goto st68
 	st68:
 		if p++; p == pe {
 			goto _test_eof68
@@ -1344,80 +1339,226 @@ tr22:
 		}
 		goto st1
 	st_out:
-	_test_eof1: cs = 1; goto _test_eof
-	_test_eof2: cs = 2; goto _test_eof
-	_test_eof3: cs = 3; goto _test_eof
-	_test_eof4: cs = 4; goto _test_eof
-	_test_eof5: cs = 5; goto _test_eof
-	_test_eof6: cs = 6; goto _test_eof
-	_test_eof7: cs = 7; goto _test_eof
-	_test_eof8: cs = 8; goto _test_eof
-	_test_eof9: cs = 9; goto _test_eof
-	_test_eof10: cs = 10; goto _test_eof
-	_test_eof11: cs = 11; goto _test_eof
-	_test_eof12: cs = 12; goto _test_eof
-	_test_eof13: cs = 13; goto _test_eof
-	_test_eof14: cs = 14; goto _test_eof
-	_test_eof15: cs = 15; goto _test_eof
-	_test_eof16: cs = 16; goto _test_eof
-	_test_eof17: cs = 17; goto _test_eof
-	_test_eof18: cs = 18; goto _test_eof
-	_test_eof71: cs = 71; goto _test_eof
-	_test_eof19: cs = 19; goto _test_eof
-	_test_eof20: cs = 20; goto _test_eof
-	_test_eof21: cs = 21; goto _test_eof
-	_test_eof22: cs = 22; goto _test_eof
-	_test_eof23: cs = 23; goto _test_eof
-	_test_eof24: cs = 24; goto _test_eof
-	_test_eof25: cs = 25; goto _test_eof
-	_test_eof26: cs = 26; goto _test_eof
-	_test_eof27: cs = 27; goto _test_eof
-	_test_eof28: cs = 28; goto _test_eof
-	_test_eof29: cs = 29; goto _test_eof
-	_test_eof30: cs = 30; goto _test_eof
-	_test_eof31: cs = 31; goto _test_eof
-	_test_eof32: cs = 32; goto _test_eof
-	_test_eof33: cs = 33; goto _test_eof
-	_test_eof34: cs = 34; goto _test_eof
-	_test_eof35: cs = 35; goto _test_eof
-	_test_eof36: cs = 36; goto _test_eof
-	_test_eof37: cs = 37; goto _test_eof
-	_test_eof38: cs = 38; goto _test_eof
-	_test_eof39: cs = 39; goto _test_eof
-	_test_eof40: cs = 40; goto _test_eof
-	_test_eof41: cs = 41; goto _test_eof
-	_test_eof42: cs = 42; goto _test_eof
-	_test_eof43: cs = 43; goto _test_eof
-	_test_eof44: cs = 44; goto _test_eof
-	_test_eof45: cs = 45; goto _test_eof
-	_test_eof46: cs = 46; goto _test_eof
-	_test_eof47: cs = 47; goto _test_eof
-	_test_eof48: cs = 48; goto _test_eof
-	_test_eof49: cs = 49; goto _test_eof
-	_test_eof50: cs = 50; goto _test_eof
-	_test_eof51: cs = 51; goto _test_eof
-	_test_eof52: cs = 52; goto _test_eof
-	_test_eof53: cs = 53; goto _test_eof
-	_test_eof54: cs = 54; goto _test_eof
-	_test_eof55: cs = 55; goto _test_eof
-	_test_eof56: cs = 56; goto _test_eof
-	_test_eof57: cs = 57; goto _test_eof
-	_test_eof58: cs = 58; goto _test_eof
-	_test_eof59: cs = 59; goto _test_eof
-	_test_eof60: cs = 60; goto _test_eof
-	_test_eof61: cs = 61; goto _test_eof
-	_test_eof62: cs = 62; goto _test_eof
-	_test_eof63: cs = 63; goto _test_eof
-	_test_eof64: cs = 64; goto _test_eof
-	_test_eof65: cs = 65; goto _test_eof
-	_test_eof66: cs = 66; goto _test_eof
-	_test_eof67: cs = 67; goto _test_eof
-	_test_eof68: cs = 68; goto _test_eof
-	_test_eof69: cs = 69; goto _test_eof
-	_test_eof70: cs = 70; goto _test_eof
+	_test_eof1:
+		cs = 1
+		goto _test_eof
+	_test_eof2:
+		cs = 2
+		goto _test_eof
+	_test_eof3:
+		cs = 3
+		goto _test_eof
+	_test_eof4:
+		cs = 4
+		goto _test_eof
+	_test_eof5:
+		cs = 5
+		goto _test_eof
+	_test_eof6:
+		cs = 6
+		goto _test_eof
+	_test_eof7:
+		cs = 7
+		goto _test_eof
+	_test_eof8:
+		cs = 8
+		goto _test_eof
+	_test_eof9:
+		cs = 9
+		goto _test_eof
+	_test_eof10:
+		cs = 10
+		goto _test_eof
+	_test_eof11:
+		cs = 11
+		goto _test_eof
+	_test_eof12:
+		cs = 12
+		goto _test_eof
+	_test_eof13:
+		cs = 13
+		goto _test_eof
+	_test_eof14:
+		cs = 14
+		goto _test_eof
+	_test_eof15:
+		cs = 15
+		goto _test_eof
+	_test_eof16:
+		cs = 16
+		goto _test_eof
+	_test_eof17:
+		cs = 17
+		goto _test_eof
+	_test_eof18:
+		cs = 18
+		goto _test_eof
+	_test_eof71:
+		cs = 71
+		goto _test_eof
+	_test_eof19:
+		cs = 19
+		goto _test_eof
+	_test_eof20:
+		cs = 20
+		goto _test_eof
+	_test_eof21:
+		cs = 21
+		goto _test_eof
+	_test_eof22:
+		cs = 22
+		goto _test_eof
+	_test_eof23:
+		cs = 23
+		goto _test_eof
+	_test_eof24:
+		cs = 24
+		goto _test_eof
+	_test_eof25:
+		cs = 25
+		goto _test_eof
+	_test_eof26:
+		cs = 26
+		goto _test_eof
+	_test_eof27:
+		cs = 27
+		goto _test_eof
+	_test_eof28:
+		cs = 28
+		goto _test_eof
+	_test_eof29:
+		cs = 29
+		goto _test_eof
+	_test_eof30:
+		cs = 30
+		goto _test_eof
+	_test_eof31:
+		cs = 31
+		goto _test_eof
+	_test_eof32:
+		cs = 32
+		goto _test_eof
+	_test_eof33:
+		cs = 33
+		goto _test_eof
+	_test_eof34:
+		cs = 34
+		goto _test_eof
+	_test_eof35:
+		cs = 35
+		goto _test_eof
+	_test_eof36:
+		cs = 36
+		goto _test_eof
+	_test_eof37:
+		cs = 37
+		goto _test_eof
+	_test_eof38:
+		cs = 38
+		goto _test_eof
+	_test_eof39:
+		cs = 39
+		goto _test_eof
+	_test_eof40:
+		cs = 40
+		goto _test_eof
+	_test_eof41:
+		cs = 41
+		goto _test_eof
+	_test_eof42:
+		cs = 42
+		goto _test_eof
+	_test_eof43:
+		cs = 43
+		goto _test_eof
+	_test_eof44:
+		cs = 44
+		goto _test_eof
+	_test_eof45:
+		cs = 45
+		goto _test_eof
+	_test_eof46:
+		cs = 46
+		goto _test_eof
+	_test_eof47:
+		cs = 47
+		goto _test_eof
+	_test_eof48:
+		cs = 48
+		goto _test_eof
+	_test_eof49:
+		cs = 49
+		goto _test_eof
+	_test_eof50:
+		cs = 50
+		goto _test_eof
+	_test_eof51:
+		cs = 51
+		goto _test_eof
+	_test_eof52:
+		cs = 52
+		goto _test_eof
+	_test_eof53:
+		cs = 53
+		goto _test_eof
+	_test_eof54:
+		cs = 54
+		goto _test_eof
+	_test_eof55:
+		cs = 55
+		goto _test_eof
+	_test_eof56:
+		cs = 56
+		goto _test_eof
+	_test_eof57:
+		cs = 57
+		goto _test_eof
+	_test_eof58:
+		cs = 58
+		goto _test_eof
+	_test_eof59:
+		cs = 59
+		goto _test_eof
+	_test_eof60:
+		cs = 60
+		goto _test_eof
+	_test_eof61:
+		cs = 61
+		goto _test_eof
+	_test_eof62:
+		cs = 62
+		goto _test_eof
+	_test_eof63:
+		cs = 63
+		goto _test_eof
+	_test_eof64:
+		cs = 64
+		goto _test_eof
+	_test_eof65:
+		cs = 65
+		goto _test_eof
+	_test_eof66:
+		cs = 66
+		goto _test_eof
+	_test_eof67:
+		cs = 67
+		goto _test_eof
+	_test_eof68:
+		cs = 68
+		goto _test_eof
+	_test_eof69:
+		cs = 69
+		goto _test_eof
+	_test_eof70:
+		cs = 70
+		goto _test_eof
 
-	_test_eof: {}
-	_out: {}
+	_test_eof:
+		{
+		}
+	_out:
+		{
+		}
 	}
 
 //line machine.rl:53

--- a/decoder/internal/machine.rl
+++ b/decoder/internal/machine.rl
@@ -1,4 +1,4 @@
-package decoder
+package internal
 
 %%{
 	machine decoder;

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,9 @@ require (
 	github.com/coocood/freecache v1.0.1
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gogo/protobuf v1.1.1
+	github.com/google/go-cmp v0.2.0 // indirect
 	github.com/google/gopacket v1.1.15
-	github.com/negbie/heplify v0.0.0-20181120122932-afa654d1922f
+	github.com/mdlayher/raw v0.0.0-20181016155347-fa5ef3332ca9 // indirect
 	github.com/negbie/logp v0.0.0-20181018124411-1d803349a741
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
@@ -7,14 +8,17 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gogo/protobuf v1.1.1 h1:72R+M5VuhED/KujmZVcIquuo8mBgX4oVda//DQb3PXo=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
+github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
+github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/gopacket v1.1.15 h1:M6W3hwQXo5rq1wyhRByGhqOw0m9p+HWtUJ3Bj4/fT6E=
 github.com/google/gopacket v1.1.15/go.mod h1:UCLx9mCmAwsVbn6qQl1WIEt2SO7Nd2fD0th1TBAsqBw=
-github.com/negbie/heplify v0.0.0-20181120122932-afa654d1922f h1:G7Lnhnxu48REq3jEaps1yXGWuqEXmqW8TkdeiSyU/1M=
-github.com/negbie/heplify v0.0.0-20181120122932-afa654d1922f/go.mod h1:VNGqX02c4R+6z+d/eUE+OPZHaA1Ev71im7NST9jYbg0=
+github.com/mdlayher/raw v0.0.0-20181016155347-fa5ef3332ca9 h1:tOtO8DXiNGj9NshRKHWiZuGlSldPFzFCFYhNtsKTBCs=
+github.com/mdlayher/raw v0.0.0-20181016155347-fa5ef3332ca9/go.mod h1:rC/yE65s/DoHB6BzVOUBNYBGTg772JVytyAytffIZkY=
 github.com/negbie/logp v0.0.0-20181018124411-1d803349a741 h1:wElbd5Pw1mg/mlE9rABTI1370wL469yNL02YxJoCKqk=
 github.com/negbie/logp v0.0.0-20181018124411-1d803349a741/go.mod h1:xTKf9aKLuVL0r9wxWouR+/4ctK2ywm0rTPFY2klrnOg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/sniffer/sniffer.go
+++ b/sniffer/sniffer.go
@@ -310,7 +310,7 @@ LOOP:
 				ci.Timestamp = time.Now()
 			}
 		} else if sniffer.config.WriteFile != "" {
-			sniffer.dumpChan <- &dump.Packet{ci, data}
+			sniffer.dumpChan <- &dump.Packet{Ci: ci, Data: data}
 		}
 
 		sniffer.worker.OnPacket(data, &ci)


### PR DESCRIPTION
You should enable the project in Travis CI in order to use the continuous integration service. Here's what the build log looks like: https://travis-ci.org/mauri870/heplify/builds/459192929.

I also have to isolate the rangel file and autogenerated code in a package `decoder/internal` to prevent `go vet` from failing.

Refs: #89 