### PR TITLE
use un-quoted payload when logging into files

### DIFF
--- a/publish/marshal.go
+++ b/publish/marshal.go
@@ -4,7 +4,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
-	"strconv"
 	strings "strings"
 	"unsafe"
 
@@ -339,7 +338,7 @@ func (h *HepMsg) String() string {
 	if h == nil {
 		return "nil"
 	}
-	s := strings.Join([]string{`&HEP{`,
+	s := strings.Join([]string{`HEP package: {`,
 		`Version:` + fmt.Sprintf("%v", h.Version) + `,`,
 		`Protocol:` + fmt.Sprintf("%v", h.Protocol) + `,`,
 		`SrcIP:` + fmt.Sprintf("%v", h.SrcIP) + `,`,
@@ -351,12 +350,11 @@ func (h *HepMsg) String() string {
 		`ProtoType:` + fmt.Sprintf("%v", h.ProtoType) + `,`,
 		`NodeID:` + fmt.Sprintf("%v", h.NodeID) + `,`,
 		`NodePW:` + fmt.Sprintf("%s", h.NodePW) + `,`,
-		`Payload:` + fmt.Sprintf("%s", strconv.Quote(string(h.Payload))) + `,`,
 		`CID:` + fmt.Sprintf("%s", h.CID) + `,`,
-		`Vlan:` + fmt.Sprintf("%v", h.Vlan) + `,`,
+		`Vlan:` + fmt.Sprintf("%v", h.Vlan),
 		`}`,
 	}, "")
-	return s
+	return s + " with Payload:\n" + fmt.Sprintf("%s", string(h.Payload))
 }
 
 func unsafeBytesToStr(z []byte) string {

--- a/publish/marshal.go
+++ b/publish/marshal.go
@@ -338,7 +338,7 @@ func (h *HepMsg) String() string {
 	if h == nil {
 		return "nil"
 	}
-	s := strings.Join([]string{`HEP package: {`,
+	s := strings.Join([]string{`HEP packet:{`,
 		`Version:` + fmt.Sprintf("%v", h.Version) + `,`,
 		`Protocol:` + fmt.Sprintf("%v", h.Protocol) + `,`,
 		`SrcIP:` + fmt.Sprintf("%v", h.SrcIP) + `,`,


### PR DESCRIPTION
Use better format when logging into files.(removed `quote()` function)

Example log in file:
```
2020-02-06T16:49:23Z INFO HEP packet:{Version:2,Protocol:17,SrcIP:35.233.182.194,DstIP:172.31.29.80,SrcPort:15060,DstPort:5060,Tsec:1581007763,Tmsec:460673,ProtoType:1,NodeID:2002
,NodePW:,CID:,Vlan:0} with Payload:
SIP/2.0 200 OK
Via: SIP/2.0/UDP 3.113.15.75:5060;branch=z9hG4bKd629.6e427557.0
From: <sip:dispatcher@localhost>;tag=3fb2ef1b2852ede23a85635eb60d3af5-274f
To: <sip:freeswitch.dashbase.io:15060>;tag=D92HjmNaDee3c
Call-ID: 542c228538fc618d-25732@0.0.0.0
CSeq: 14 OPTIONS
Contact: <sip:35.233.182.194:15060>
User-Agent: FreeSWITCH-mod_sofia/1.10.2-release-13-f7bdd3845a~64bit
Accept: application/sdp
Allow: INVITE, ACK, BYE, CANCEL, OPTIONS, MESSAGE, INFO, UPDATE, REGISTER, REFER, NOTIFY, PUBLISH, SUBSCRIBE
Supported: timer, path, replaces
Allow-Events: talk, hold, conference, presence, as-feature-event, dialog, line-seize, call-info, sla, include-session-description, presence.winfo, message-summary, refer
Content-Length: 0
```
Example log in syslog:
```
2020-02-06T16:51:50.511688+00:00 ip-172-31-29-80 ./heplify[23816]: file.go:20: HEP packet:{Version:2,Protocol:17,SrcIP:35.233.182.194,DstIP:172.31.29.80,SrcPort:15060,DstPort:5060,Tsec:1581007909,Tmsec:489384,ProtoType:1,NodeID:2002,NodePW:,CID:,Vlan:0} with Payload:#012SIP/2.0 407 Proxy Authentication Required#015#012Via: SIP/2.0/UDP 3.113.15.75:5060;branch=z9hG4bK2f38.45e3a537.0#015#012Via: SIP/2.0/UDP 185.53.88.29:49432;branch=z9hG4bK49679476#015#012From: <sip:105@3.113.15.75>;tag=1425735984#015#012To: <sip:300972599924215@3.113.15.75>;tag=3jaZ3cSar9j1K#015#012Call-ID: 1265477378-112730891-1965850099#015#012CSeq: 1 INVITE#015#012User-Agent: FreeSWITCH-mod_sofia/1.10.2-release-13-f7bdd3845a~64bit#015#012Accept: application/sdp#015#012Allow: INVITE, ACK, BYE, CANCEL, OPTIONS, MESSAGE, INFO, UPDATE, REGISTER, REFER, NOTIFY, PUBLISH, SUBSCRIBE#015#012Supported: timer, path, replaces#015#012Allow-Events: talk, hold, conference, presence, as-feature-event, dialog, line-seize, call-info, sla, include-session-description, presence.winfo, message-summary, refer#015#012Proxy-Authenticate: Digest realm="3.113.15.75", nonce="52103d4f-9154-41c9-a479-0bce21c2af43", algorithm=MD5, qop="auth"#015#012Content-Length: 0
```