### PR TITLE
better rtcp correlation

### DIFF
--- a/decoder/correlator.go
+++ b/decoder/correlator.go
@@ -38,12 +38,13 @@ var (
 // As we can not known which is the correct one we add two keys in this case.
 // Key parts will be separated by a single space.
 func addSDPCacheEntry(srcIP []byte, rtcpIP []byte, rtcpPort []byte, callID []byte) {
-	var key []byte = nil
-	key = append(append(append(key, rtcpIP...), ' '), rtcpPort...)
+	var buffer [60]byte // use large enough buffer on stack for fast append
+	var key []byte
+	key = append(append(append(buffer[:0], rtcpIP...), ' '), rtcpPort...)
 	logp.Debug("sdp", "Add to sdpCache key=%q, value=%q", key, callID)
 	sdpCache.Set(key, callID, sdpCacheTime)
 	if !bytes.Equal(rtcpIP, srcIP) {
-		key = append(append(append(key[:0], srcIP...), ' '), rtcpPort...)
+		key = append(append(append(buffer[:0], srcIP...), ' '), rtcpPort...)
 		logp.Debug("sdp", "Add to sdpCache key=%q, value=%q", key, callID)
 		sdpCache.Set(key, callID, sdpCacheTime)
 	}

--- a/decoder/correlator.go
+++ b/decoder/correlator.go
@@ -24,7 +24,7 @@ var (
 // It will do this only for SIP messages which have the strings "c=IN IP4 " and "m=audio " in the SDP body.
 // If there is one rtcp attribute in the SDP body it will use it as RTCP port. Otherwise it will add 1 to
 // the RTP source port. These data will be used for the SDPCache as key:value pairs.
-func cacheSDPIPPort(payload []byte) {
+func cacheSDPIPPort(srcIP net.IP, srcPort uint16, dstIP net.IP, dstPort uint16, payload []byte) {
 	if posSDPIP := bytes.Index(payload, cLine); posSDPIP > 0 {
 		if posSDPPort := bytes.Index(payload, mLine); posSDPPort > 0 {
 			ipPort.Reset()

--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -350,7 +350,7 @@ func (d *Decoder) processTransport(foundLayerTypes *[]gopacket.LayerType, udp *l
 						return
 					}
 				}
-				cacheSDPIPPort(udp.Payload)
+				cacheSDPIPPort(pkt.SrcIP, pkt.SrcPort, pkt.DstIP, pkt.DstPort, pkt.Payload)
 			}
 
 		case layers.LayerTypeTCP:
@@ -364,7 +364,7 @@ func (d *Decoder) processTransport(foundLayerTypes *[]gopacket.LayerType, udp *l
 				d.asm.AssembleWithTimestamp(flow, tcp, ci.Timestamp)
 				return
 			}
-			cacheSDPIPPort(pkt.Payload)
+			cacheSDPIPPort(pkt.SrcIP, pkt.SrcPort, pkt.DstIP, pkt.DstPort, pkt.Payload)
 
 		case layers.LayerTypeSCTP:
 			pkt.SrcPort = uint16(sctp.SrcPort)
@@ -378,7 +378,7 @@ func (d *Decoder) processTransport(foundLayerTypes *[]gopacket.LayerType, udp *l
 			atomic.AddUint64(&d.sctpCount, 1)
 			logp.Debug("payload", "SCTP:\n%s", pkt)
 
-			cacheSDPIPPort(pkt.Payload)
+			cacheSDPIPPort(pkt.SrcIP, pkt.SrcPort, pkt.DstIP, pkt.DstPort, pkt.Payload)
 
 		case layers.LayerTypeDNS:
 			if config.Cfg.Mode == "SIPDNS" {

--- a/decoder/tcpassembly.go
+++ b/decoder/tcpassembly.go
@@ -101,7 +101,7 @@ func (s *tcpStream) run() {
 				}
 				data = nil
 				PacketQueue <- pkt
-				cacheSDPIPPort(pkt.Payload)
+				cacheSDPIPPort(pkt.SrcIP, pkt.SrcPort, pkt.DstIP, pkt.DstPort, pkt.Payload)
 				//logp.Debug("tcpassembly", "%s", pkt)
 				//fmt.Printf("###################\n%s", pkt.Payload)
 			}


### PR DESCRIPTION
Hello,

I have run into some issues with the current rtcp correlation:
- extraction of a=rtcp ignores optional ip and generates wrong key.
- only the last byte of the rtp port is incremented, which fails for ports ending in 9.
- keys do not use separators between parts, which gives ambiguous keys. E.g. "1.1.1.123000", where 2 could be part of ip or port.
- sip send through nat may contain a private ip in sdp, so that rtcp will not be corellated.
- rtcp keys uses only ssrc, which is only unique for a session, not for different calls. E.g. with multiple call-legs or when using some sip tools.

To address these issues I have
- extended cacheSDPIPPort signature to include the ips and ports like correlateRTCP does.
- rewritten cacheSDPIPPort to index all rtcp endpoints from sdp, including natted ones.
- allow rtcp endpoint extraction even if some seldom found sdp features are present, like LF-only separators, multi-port and multi-ip notation or ttl for multicast addresses.
- changed the cache keys to include separators.
- changed correlateRTCP to use ip+port+ssrc as key.

Additionally I added some helper functions for extracting values from RFC2822 like header data, added a lot of comments and more debug output.