### PR TITLE
process CID(correlationID) and add CID to SIP messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ docker build --no-cache -t sipcapture/heplify:latest -f docker/heplify/Dockerfil
   -hi   HEP Node ID (default 2002)
   -di   Discard uninteresting packets by string
   -dim  Discard uninteresting SIP packets by CSeq [OPTIONS,NOTIFY]
+  -cid  remove prefix from correlationID which is obtain from callID [asbc,isbc,sbcpfx]
   -fi   Filter interesting packets by string
   -rf   Read PCAP file
   -rs   Use original timestamps when reading PCAP file

--- a/config/config.go
+++ b/config/config.go
@@ -7,22 +7,23 @@ import (
 var Cfg Config
 
 type Config struct {
-	Iface         *InterfacesConfig
-	Logging       *logp.Logging
-	Mode          string
-	Dedup         bool
-	Filter        string
-	Discard       string
-	DiscardMethod string
-	Zip           bool
-	HepServer     string
-	HepNodePW     string
-	HepNodeID     uint
-	HepNodeName   string
-	Network       string
-	Protobuf      bool
-	Reassembly    bool
-	Version       bool
+	Iface           *InterfacesConfig
+	Logging         *logp.Logging
+	Mode            string
+	Dedup           bool
+	Filter          string
+	CIDPrefix       string
+	Discard         string
+	DiscardMethod   string
+	Zip             bool
+	HepServer       string
+	HepNodePW       string
+	HepNodeID       uint
+	HepNodeName     string
+	Network         string
+	Protobuf        bool
+	Reassembly      bool
+	Version         bool
 }
 
 type InterfacesConfig struct {

--- a/decoder/tcpassembly.go
+++ b/decoder/tcpassembly.go
@@ -105,6 +105,11 @@ func (s *tcpStream) run() {
 					pkt.Payload = d
 				}
 				data = nil
+				
+				//**need comment:
+				//looking at this, it seems i should process CID for this packet as well before it being send to the queue
+				//however i am not very sure how i can all the decoder.processCID from here. 
+				//Do i have to recreate the function and reassign the String[] filterCIDPrefix here?
 				PacketQueue <- pkt
 				extractCID(pkt.SrcIP, pkt.SrcPort, pkt.DstIP, pkt.DstPort, pkt.Payload)
 				//logp.Debug("tcpassembly", "%s", pkt)

--- a/main.go
+++ b/main.go
@@ -57,6 +57,7 @@ func createFlags() {
 	flag.BoolVar(&config.Cfg.Dedup, "dd", false, "Deduplicate packets")
 	flag.StringVar(&config.Cfg.Discard, "di", "", "Discard uninteresting packets by any string")
 	flag.StringVar(&config.Cfg.DiscardMethod, "dim", "", "Discard uninteresting SIP packets by CSeq [OPTIONS,NOTIFY]")
+	flag.StringVar(&config.Cfg.CIDPrefix, "cid", "", "remove prefix from correlationID which is obtain from callID [asbc,isbc,sbcpfx]")
 	flag.StringVar(&config.Cfg.Filter, "fi", "", "Filter interesting packets by any string")
 	flag.StringVar(&config.Cfg.HepServer, "hs", "127.0.0.1:9060", "HEP server address")
 	flag.StringVar(&config.Cfg.HepNodePW, "hp", "", "HEP node PW")


### PR DESCRIPTION
Do this before sending to PacketQueue
1. process correlationID(CID) to remove prefix
2. add CID to all SIP messages (this will later be used in heplify-server to replace CallID when inserting to DB)

All this is done to distribute the data processing for SIP Call correlation to Heplify instead of doing it at heplify-server

**need some comment for tcpassembly.go