### PR TITLE
discard packets by src ips

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 heplify
+heplify.log*
+vendor/

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	Filter        string
 	Discard       string
 	DiscardMethod string
+	DiscardSrcIP  string
 	Zip           bool
 	HepServer     string
 	HepNodePW     string

--- a/main.go
+++ b/main.go
@@ -57,6 +57,7 @@ func createFlags() {
 	flag.BoolVar(&config.Cfg.Dedup, "dd", false, "Deduplicate packets")
 	flag.StringVar(&config.Cfg.Discard, "di", "", "Discard uninteresting packets by any string")
 	flag.StringVar(&config.Cfg.DiscardMethod, "dim", "", "Discard uninteresting SIP packets by CSeq [OPTIONS,NOTIFY]")
+	flag.StringVar(&config.Cfg.DiscardSrcIP, "disip", "", "Discard uninteresting SIP packets by Source IP(s)")
 	flag.StringVar(&config.Cfg.Filter, "fi", "", "Filter interesting packets by any string")
 	flag.StringVar(&config.Cfg.HepServer, "hs", "127.0.0.1:9060", "HEP server address")
 	flag.StringVar(&config.Cfg.HepNodePW, "hp", "", "HEP node PW")


### PR DESCRIPTION
Heplify is an awesome tool, but I find situations, where I cannot filter packets by source IP. This PR added a command option that allows heplify to drop packets from specific source IP(s).


Verified by reading PCAP files.