### PR TITLE
Adds Discard uninteresting SIP packets by Destination IP(s) flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ docker build --no-cache -t sipcapture/heplify:latest -f docker/heplify/Dockerfil
     	Deduplicate packets
   -di string
     	Discard uninteresting packets by any string
+  -didip string
+        Discard uninteresting SIP packets by Destination IP(s)
   -dim string
     	Discard uninteresting SIP packets by CSeq [OPTIONS,NOTIFY]
   -disip string

--- a/README.md
+++ b/README.md
@@ -49,8 +49,6 @@ docker build --no-cache -t sipcapture/heplify:latest -f docker/heplify/Dockerfil
     	Deduplicate packets
   -di string
     	Discard uninteresting packets by any string
-  -didip string
-        Discard uninteresting SIP packets by Destination IP(s)
   -dim string
     	Discard uninteresting SIP packets by CSeq [OPTIONS,NOTIFY]
   -disip string

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,8 @@ type Config struct {
 	DiscardDstIP  string
 	Zip           bool
 	HepServer     string
+	HepCollector   string
+	CollectOnlySip bool
 	HepNodePW     string
 	HepNodeID     uint
 	HepNodeName   string

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	Discard       string
 	DiscardMethod string
 	DiscardSrcIP  string
+	DiscardDstIP  string
 	Zip           bool
 	HepServer     string
 	HepNodePW     string

--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -46,6 +46,7 @@ type Decoder struct {
 	dedupCache    *freecache.Cache
 	filter        []string
 	filterSrcIP   []string
+	filterDstIP   []string
 	stats
 }
 
@@ -127,6 +128,7 @@ func NewDecoder(datalink layers.LinkType) *Decoder {
 
 	d.filter = strings.Split(strings.ToUpper(config.Cfg.DiscardMethod), ",")
 	d.filterSrcIP = strings.Split(config.Cfg.DiscardSrcIP, ",")
+	d.filterDstIP = strings.Split(config.Cfg.DiscardDstIP, ",")
 
 	if config.Cfg.Dedup {
 		d.dedupCache = freecache.NewCache(20 * 1024 * 1024) // 20 MB
@@ -296,6 +298,14 @@ func (d *Decoder) processTransport(foundLayerTypes *[]gopacket.LayerType, udp *l
 	if config.Cfg.DiscardSrcIP != "" {
 		for _, v := range d.filterSrcIP {
 			if sIP.String() == v {
+				return
+			}
+		}
+	}
+
+	if config.Cfg.DiscardDstIP != "" {
+		for _, v := range d.filterDstIP {
+			if dIP.String() == v {
 				return
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -63,6 +63,7 @@ func createFlags() {
 	flag.StringVar(&config.Cfg.Discard, "di", "", "Discard uninteresting packets by any string")
 	flag.StringVar(&config.Cfg.DiscardMethod, "dim", "", "Discard uninteresting SIP packets by CSeq [OPTIONS,NOTIFY]")
 	flag.StringVar(&config.Cfg.DiscardSrcIP, "disip", "", "Discard uninteresting SIP packets by Source IP(s)")
+	flag.StringVar(&config.Cfg.DiscardDstIP, "didip", "", "Discard uninteresting SIP packets by Destination IP(s)")
 	flag.StringVar(&config.Cfg.Filter, "fi", "", "Filter interesting packets by any string")
 	flag.StringVar(&config.Cfg.HepServer, "hs", "127.0.0.1:9060", "HEP server address")
 	flag.StringVar(&config.Cfg.HepNodePW, "hp", "", "HEP node PW")


### PR DESCRIPTION
Adds a new flag to support discarding SIP packets by destination IP(s)

Same logic as already implemented src IP, just adds it for dst IP(s) also 