### PR TITLE
Update Dockerfile to enable non-root user with cap_add

### DIFF
--- a/docker/heplify/Dockerfile
+++ b/docker/heplify/Dockerfile
@@ -6,7 +6,9 @@ COPY . /heplify
 WORKDIR /heplify
 RUN CGO_ENABLED=1 GOOS=linux go build -a --ldflags '-linkmode external -extldflags "-static -s -w"' -o heplify .
 
-FROM scratch
+FROM alpine
+RUN apk --no-cache add ca-certificates tzdata libcap
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /heplify/heplify .
+RUN /usr/sbin/setcap cap_net_raw,cap_net_admin=eip heplify
 CMD ["./heplify", "-h"]


### PR DESCRIPTION
In order to run the heplify container as a non root user, and then use capabilities (cap_add) to enable promiscous mode for the heplify binary, we need to set those capabilites on the heplify binary in the image.