### PR TITLE
fix: tcpassembly does not use correct timestamps

### DIFF
--- a/decoder/tcpassembly.go
+++ b/decoder/tcpassembly.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/tcpassembly"
-	"github.com/negbie/logp"
+	// "github.com/negbie/logp"
 	"github.com/sipcapture/heplify/protos"
 )
 

--- a/decoder/tcpassembly.go
+++ b/decoder/tcpassembly.go
@@ -3,13 +3,12 @@ package decoder
 import (
 	"bytes"
 	"encoding/binary"
-	"io"
+	"errors"
 	"strconv"
 	"time"
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/tcpassembly"
-	"github.com/google/gopacket/tcpassembly/tcpreader"
 	"github.com/negbie/logp"
 	"github.com/sipcapture/heplify/protos"
 )
@@ -32,106 +31,198 @@ func (s *tcpStreamFactory) New(net, transport gopacket.Flow) tcpassembly.Stream 
 }
 
 type readerStream struct {
-	tcpreader.ReaderStream
-	InitialTS time.Time
+	tcpassembly.Stream
+	ReassembledChan chan tcpassembly.Reassembly
+	Closed bool
 }
 
 func newReaderStream() readerStream {
 	return readerStream{
-		ReaderStream: tcpreader.NewReaderStream(),
+		ReassembledChan: make(chan tcpassembly.Reassembly),
+		Closed: false,
 	}
 }
 
-func (r *readerStream) Reassembled(reassembly []tcpassembly.Reassembly) {
-	if r.InitialTS.IsZero() && len(reassembly) > 0 {
-		r.InitialTS = reassembly[0].Seen
+func (r *readerStream) Reassembled(reassembled []tcpassembly.Reassembly) {
+	for _, reassembly := range reassembled {
+		r.ReassembledChan <- reassembly
 	}
-	r.ReaderStream.Reassembled(reassembly)
+}
+
+func (r *readerStream) ReassemblyComplete() {
+	close(r.ReassembledChan)
+	r.Closed = true
 }
 
 func (s *tcpStream) run() {
-	var data []byte
-	var tmp = make([]byte, 4096)
-	ts := time.Now()
+	var tsUnset time.Time = time.Unix(0, 0)
+	var ts time.Time = tsUnset
+	var data []byte = make([]byte, 0)
+	var reassembly tcpassembly.Reassembly
+	var again bool = false
+	var ignore bool = false
 	for {
-		n, err := s.readerStream.Read(tmp)
-		if err == io.EOF {
-			return
-		} else if err != nil {
-			logp.Err("got %v while reading temporary buffer", err)
-			continue
-		} else if n > 0 {
-			/* we should make a correct timestamp */
-			if data == nil {
-				ts = time.Now()
+		if again {
+			// Check remainder of data again without getting next packet.
+			again = false
+		} else {
+			// Get next packet.
+			reassembly, more := <- s.readerStream.ReassembledChan
+			if !more {
+				return
 			}
-
-			data = append(data, tmp[0:n]...)
-
-			if bytes.HasPrefix(data, []byte("GET")) || bytes.HasPrefix(data, []byte("HTTP")) {
-				data = nil
+			// logp.Debug("tcpassembly", "src=%s-%s dst=%s-&s reassembly=%s", s.net.Src(), s.transport.Src(), s.net.Dst(), s.transport.Dst(), reassembly)
+			// Check for mising data.
+			// Missing data is normal. The assembly is flusehd every second, which closes connections which did not receive new data.
+			if reassembly.Skip != 0 {
+				// logp.Debug("tcpassembly", "detected lost packets")
+				// Discard collected data and try to continue
+				data = data[0:0]
+				ts = tsUnset
+			}
+			// Should we ignore all packets?
+			if ignore {
 				continue
 			}
-
-			var d []byte
-			var isWS bool
-			if (data[0] == 129 || data[0] == 130) && (data[1] == 126 || data[1] == 254) {
-				d, err = protos.WSPayload(data)
-				if err == nil {
-					isWS = true
-				}
+			// Skip empty packets.
+			if len(reassembly.Bytes) == 0 {
+				continue
 			}
+			// Remember start time.
+			if ts == tsUnset {
+				ts = reassembly.Seen
+			}
+			// Collect data.
+			data = append(data, reassembly.Bytes...)
+			logp.Info("data=", data)
+		}
 
-			if isWS || isSIP(data) {
-				pkt := &Packet{}
-				pkt.Version = 0x02
-				pkt.Protocol = 0x06
-				pkt.SrcIP = s.net.Src().Raw()
-				pkt.DstIP = s.net.Dst().Raw()
-				sp := s.transport.Src().Raw()
-				dp := s.transport.Dst().Raw()
-				if len(sp) == 2 && len(dp) == 2 {
-					pkt.SrcPort = binary.BigEndian.Uint16(sp)
-					pkt.DstPort = binary.BigEndian.Uint16(dp)
+		// Skip if empty.
+		if len(data) == 0 {
+			continue
+		}
+
+		// Check for websocket upgrade.
+		if bytes.HasPrefix(data, []byte("GET")) || bytes.HasPrefix(data, []byte("HTTP")) {
+			var msgLen = bytes.Index(data, []byte("\r\n\r\n")) + 4
+			if msgLen > 4 {
+				// Found end of HTTP request/response.
+				// Skip this message and start new message.
+				data = data[msgLen:]
+				if len(data) > 0 {
+					again = true
+					ts = reassembly.Seen
+
+				} else {
+					ts = tsUnset
 				}
-				if len(pkt.SrcIP) > 4 || len(pkt.DstIP) > 4 {
-					pkt.Version = 0x0a
-				}
-				pkt.Tsec = uint32(ts.Unix())
-				pkt.Tmsec = uint32(ts.Nanosecond() / 1000)
-				pkt.ProtoType = 1
-				pkt.Payload = data
-				if isWS {
-					pkt.Payload = d
-				}
-				data = nil
-				PacketQueue <- pkt
-				extractCID(pkt.SrcIP, pkt.SrcPort, pkt.DstIP, pkt.DstPort, pkt.Payload)
-				//logp.Debug("tcpassembly", "%s", pkt)
-				//fmt.Printf("###################\n%s", pkt.Payload)
+				continue
+			}
+		}
+
+		var msgLen int = 0
+		var payload []byte
+		var err error
+		var isWS bool = false
+		var isSIP bool = false
+
+		// Check for websocket data.
+		if (data[0] == 129 || data[0] == 130) && (data[1] == 126 || data[1] == 254) {
+			payload, err = protos.WSPayload(data)  // TODO: will only match if data contains exactly one message.
+			if err == nil {
+				isWS = true
+				msgLen = len(data)  // TODO: should only be the length of the complete WS message.
+				// TODO: Should we not check if WS payload contains SIP and handle it?
+			}
+		} else {
+			// Check for SIP mesage.
+			payload, err = SIPMessage(data)
+			if err == nil {
+				isSIP = true
+				msgLen = len(payload)
+			}
+		}
+		// logp.Debug("tcpassembly" "isWS=%s isSIP=%s", isWS, isSIP)
+
+		if isWS || isSIP {
+			// Build HEP packet.
+			pkt := &Packet{}
+			pkt.Version = 0x02
+			pkt.Protocol = 0x06
+			pkt.SrcIP = s.net.Src().Raw()
+			pkt.DstIP = s.net.Dst().Raw()
+			sp := s.transport.Src().Raw()
+			dp := s.transport.Dst().Raw()
+			if len(sp) == 2 && len(dp) == 2 {
+				pkt.SrcPort = binary.BigEndian.Uint16(sp)
+				pkt.DstPort = binary.BigEndian.Uint16(dp)
+			}
+			if len(pkt.SrcIP) > 4 || len(pkt.DstIP) > 4 {
+				pkt.Version = 0x0a
+			}
+			pkt.Tsec = uint32(ts.Unix())
+			pkt.Tmsec = uint32(ts.Nanosecond() / 1000)
+			pkt.ProtoType = 1
+			pkt.Payload = payload
+			// logp.Debug("tcpassembly", "%s", pkt)
+			//fmt.Printf("###################\n%s", pkt.Payload)
+			// Extract information for RTP association.
+			extractCID(pkt.SrcIP, pkt.SrcPort, pkt.DstIP, pkt.DstPort, pkt.Payload)
+			// Queue HEP packet.
+			PacketQueue <- pkt
+			// Remove message from data and check remainder again.
+			data = data[msgLen:]
+			if len(data) > 0 {
+				again = true
+				ts = reassembly.Seen
+
+			} else {
+				ts = tsUnset
+			}
+		} else {
+			// Check if we accumulated to much data for a SIP message.
+			if len(data) > 1000000 {
+				// logp.Debug("tcpassembly" "collected to much data, ignoring")
+				// Remove data and ignore further data.
+				data = data[0:0]
+				ignore = true
 			}
 		}
 	}
 }
 
-func isSIP(data []byte) bool {
-	end := []byte("\r\n")
-	bodyLen := getSIPHeaderValInt("Content-Length:", data)
-	if bodyLen < 1 {
-		end = []byte("\r\n\r\n")
-	} else {
-		headerLen := bytes.Index(data, []byte("\r\n\r\n")) + 4
-		if headerLen == -1 || headerLen+bodyLen != len(data) {
-			return false
-		}
-	}
+var SIPTruncated = errors.New("not SIP")
+var NotSIP = errors.New("not SIP")
 
+func SIPMessage(data []byte) ([]byte, error) {
+	// Check that first line looks like SIP.
+	hasSIPLine := false
 	for k := range firstSIPLine {
-		if bytes.HasPrefix(data, firstSIPLine[k]) && bytes.HasSuffix(data, end) {
-			return true
+		if bytes.HasPrefix(data, firstSIPLine[k]) {
+			hasSIPLine = true
+			break
 		}
 	}
-	return false
+	if !hasSIPLine {
+		return nil, NotSIP
+	}
+	// Get length of header.
+	headerLen := bytes.Index(data, []byte("\r\n\r\n")) + 4
+	if headerLen < 4 {
+		return nil, SIPTruncated
+	}
+	// Get body length.
+	bodyLen := getSIPHeaderValInt("Content-Length:", data)
+	if bodyLen < 0 {
+		// No body.
+		bodyLen = 0
+	}
+	// Check that message is complete.
+	if len(data) < headerLen + bodyLen {
+		return nil, SIPTruncated
+	}
+	// Return message.
+	return data[:headerLen + bodyLen], nil
 }
 
 func isSDP(data []byte) bool {

--- a/decoder/tcpassembly.go
+++ b/decoder/tcpassembly.go
@@ -94,7 +94,6 @@ func (s *tcpStream) run() {
 			}
 			// Collect data.
 			data = append(data, reassembly.Bytes...)
-			logp.Info("data=", data)
 		}
 
 		// Skip if empty.


### PR DESCRIPTION
tcpassembly only read the bytes of the reassembled stream and ignored other reassembly information, like seen timestamp. Therefore When assembling a HEP packet it had to use the current time. Because of parallel handling of packet capture, reassembly, and extraction this timestamp could be totally wrong.

The changed code processes the reassembly information directly and uses the timestamp of the part with the begin of the SIP message.

refs: https://github.com/sipcapture/heplify/issues/223