### PR TITLE
Add CAP_BPF capability for non-root usage

### DIFF
--- a/docker/heplify/Dockerfile
+++ b/docker/heplify/Dockerfile
@@ -13,5 +13,5 @@ FROM alpine:3.19
 RUN apk --no-cache add ca-certificates tzdata libcap
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /heplify/heplify .
-RUN /usr/sbin/setcap cap_net_raw,cap_net_admin=eip heplify
+RUN /usr/sbin/setcap cap_bpf,cap_net_raw,cap_net_admin=eip heplify
 CMD ["./heplify", "-h"]


### PR DESCRIPTION
For some reason, the capabilitites needed to run as root, has changed a bit, so CAP_BPF is now also needed, otherwise starting the current release results in:

```
$> docker run --rm -it  --user 1001:1001 --cap-add=NET_ADMIN --cap-add=SYS_ADMIN sipcapture/heplify:latest ./heplify -e -hs 10.9.24.125:9060 -m SIP -dd -zf 
2024/10/24 09:29:48.433811 sniffer.go:117: INFO config.Config{Iface:(*config.InterfacesConfig)(0xc00010d860), Logging:(*logp.Logging)(0xc00007c050), Mode:"SIP", Dedup:true, Filter:"", Discard:"", DiscardMethod:"", DiscardSrcIP:"", Zip:true, HepServer:"10.9.24.125:9060", HepNodePW:"", HepNodeID:0x7d2, HepNodeName:"", Network:"udp", Protobuf:false, Reassembly:false, SendRetries:0x40, Version:false}
2024/10/24 09:29:48.434003 sniffer.go:118: INFO &config.InterfacesConfig{Device:"any", Type:"pcap", ReadFile:"", WriteFile:"", RotationTime:60, PortRange:"5060-5090", WithVlan:false, WithErspan:false, Snaplen:8192, BufferSizeMb:32, ReadSpeed:false, OneAtATime:false, Loop:1, FanoutID:0x0, FanoutWorker:4, CustomBPF:""}
2024/10/24 09:29:48.434042 sniffer.go:119: INFO bpf: (tcp or sctp) and greater 42 and portrange 5060-5090 or (udp and greater 128 and portrange 5060-5090 or ip[6:2] & 0x1fff != 0 or ip6[6]=44)
2024/10/24 09:29:48.434075 sniffer.go:126: INFO ostype: linux, osarch: amd64

Critical: setting pcap live mode: any: You don't have permission to perform this capture on that device (socket: Operation not permitted)

```
