### PR TITLE
fix: serialize TCP assembler flushes

### DIFF
--- a/src/cmd/heplify/version.go
+++ b/src/cmd/heplify/version.go
@@ -7,7 +7,7 @@ import (
 
 // Version is the application version. Updated by the release build process via scripts/update_version.sh.
 // Overridden at build time with -X main.Version=<ver> ldflags by GoReleaser and Makefile.
-var Version = "2.0.14"
+var Version = "2.0.15"
 
 // BuildDate is the UTC build timestamp. Set via -X main.BuildDate=<date> ldflags at build time.
 var BuildDate = "unknown"

--- a/src/decoder/decoder_test.go
+++ b/src/decoder/decoder_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"net"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -878,4 +879,44 @@ func TestTCPSIPMidStreamResync(t *testing.T) {
 	if len(received) != 1 {
 		t.Fatalf("expected 1 SIP packet, got %d (mid-stream resync failed)", len(received))
 	}
+}
+
+func TestSIPAssemblerConcurrentFeedAndFlush(t *testing.T) {
+	assembler := NewSIPAssembler(func(*Packet) {})
+	netFlow := gopacket.NewFlow(layers.EndpointIPv4, []byte{10, 0, 0, 1}, []byte{10, 0, 0, 2})
+	payload := []byte("INVITE sip:bob@example.com SIP/2.0\r\nContent-Length: 0\r\n\r\n")
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+
+	for worker := 0; worker < 4; worker++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			<-start
+			for i := 0; i < 2000; i++ {
+				tcp := &layers.TCP{
+					BaseLayer: layers.BaseLayer{Payload: payload},
+					SrcPort:   layers.TCPPort(5060 + worker),
+					DstPort:   layers.TCPPort(5060),
+					Seq:       uint32(i*len(payload) + 1),
+				}
+				assembler.Feed(netFlow, tcp, time.Now())
+			}
+		}(worker)
+	}
+
+	for worker := 0; worker < 2; worker++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for i := 0; i < 2000; i++ {
+				assembler.FlushOlderThan(time.Now().Add(time.Second))
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
 }

--- a/src/decoder/tcpassembly.go
+++ b/src/decoder/tcpassembly.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/google/gopacket"
@@ -20,6 +21,7 @@ type SIPCallback func(pkt *Packet)
 // complete SIP (or SIP-over-WebSocket) message is reassembled.
 type SIPAssembler struct {
 	asm *tcpassembly.Assembler
+	mu  sync.Mutex
 }
 
 // NewSIPAssembler creates a SIPAssembler that calls cb for every reassembled
@@ -32,11 +34,15 @@ func NewSIPAssembler(cb SIPCallback) *SIPAssembler {
 
 // Feed passes a single TCP segment to the assembler.
 func (a *SIPAssembler) Feed(netFlow gopacket.Flow, tcp *layers.TCP, ts time.Time) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	a.asm.AssembleWithTimestamp(netFlow, tcp, ts)
 }
 
 // FlushOlderThan releases streams that have not received data since t.
 func (a *SIPAssembler) FlushOlderThan(t time.Time) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	a.asm.FlushOlderThan(t)
 }
 


### PR DESCRIPTION
Protect the gopacket TCP assembler from concurrent Feed and FlushOlderThan calls to prevent runtime panics during TCP SIP reassembly, and bump the patch version to 2.0.15.