### PR TITLE
feat: HEP UDP EMSGSIZE diagnostics and IP defrag flush (v2.0.22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.22] - 2026-05-19
+
+### Added
+
+- Log `hep_bytes`, `wire_bytes`, and `hep_payload_bytes` when HEP UDP send fails with `message too long` (`EMSGSIZE`).
+- CLI flag `-print-out-bad-message` / config `debug_settings.print_out_bad_message` to dump HEP/SIP payload hex (and printable SIP text) on that error.
+- Periodic discard of stale incomplete IP fragment flows every minute (restores legacy heplify v1 behaviour; reduces memory growth from never-completed fragments).
+
+### Changed
+
+- Incomplete IP fragment flows are never emitted as HEP; the flush only drops stale state.
+
 ## [2.0.17] - 2026-04-28
 
 ### Changed

--- a/docs/CLI_ENV_CONFIG_MAPPING.md
+++ b/docs/CLI_ENV_CONFIG_MAPPING.md
@@ -69,6 +69,7 @@ This document describes how `heplify` resolves configuration from:
 | `-d` | `debug_selectors` | `HEPLIFY_DEBUG_SELECTORS__N` |
 | `-disable-defrag` | `debug_settings.disable_ip_defrag` | `HEPLIFY_DEBUG_SETTINGS_DISABLE_IP_DEFRAG` |
 | `-disable-tcp-reasm` | `debug_settings.disable_tcp_reassembly` | `HEPLIFY_DEBUG_SETTINGS_DISABLE_TCP_REASSEMBLY` |
+| `-print-out-bad-message` | `debug_settings.print_out_bad_message` | `HEPLIFY_DEBUG_SETTINGS_PRINT_OUT_BAD_MESSAGE` |
 | `-wf` | `pcap_settings.write_file` | `HEPLIFY_PCAP_SETTINGS_WRITE_FILE` |
 | `-rt` | `pcap_settings.rotate_minutes` | `HEPLIFY_PCAP_SETTINGS_ROTATE_MINUTES` |
 | `-zf` | `pcap_settings.compress` | `HEPLIFY_PCAP_SETTINGS_COMPRESS` |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -344,6 +344,7 @@ Flags to selectively disable processing subsystems (useful for troubleshooting).
 |-------|------|---------|-------------|
 | `disable_tcp_reassembly` | bool | `false` | Disable TCP stream reassembly |
 | `disable_ip_defrag` | bool | `false` | Disable IP defragmentation |
+| `print_out_bad_message` | bool | `false` | On HEP send `message too long`, dump HEP/SIP payload in the log (`hep_bytes` / `hep_payload_bytes` always logged) |
 
 ---
 

--- a/src/cmd/heplify/main.go
+++ b/src/cmd/heplify/main.go
@@ -119,8 +119,9 @@ var (
 	logPayload bool
 
 	// Debug settings
-	disableDefrag   bool
-	disableTcpReasm bool
+	disableDefrag      bool
+	disableTcpReasm    bool
+	printOutBadMessage bool
 
 	// API TLS
 	apiTLS      bool
@@ -230,6 +231,7 @@ func init() {
 	// Debug settings
 	flag.BoolVar(&disableDefrag, "disable-defrag", false, "Disable IP defragmentation")
 	flag.BoolVar(&disableTcpReasm, "disable-tcp-reasm", false, "Disable TCP reassembly processing")
+	flag.BoolVar(&printOutBadMessage, "print-out-bad-message", false, "On HEP UDP 'message too long', dump HEP/SIP payload to the log (sizes are always logged)")
 
 	// API TLS flags
 	flag.BoolVar(&apiTLS, "api-tls", false, "Enable HTTPS for API (requires -api-cert and -api-key)")
@@ -682,6 +684,7 @@ func buildConfigFromFlags() *config.Config {
 	// Debug settings
 	cfg.DebugSettings.DisableIPDefrag = disableDefrag
 	cfg.DebugSettings.DisableTcpReassembly = disableTcpReasm
+	cfg.DebugSettings.PrintOutBadMessage = printOutBadMessage
 
 	// API TLS settings
 	if apiTLS {
@@ -1212,6 +1215,9 @@ func applyExplicitCLIOverridesWithVisited(cfg *config.Config, visited []string) 
 
 		case "disable-tcp-reasm":
 			cfg.DebugSettings.DisableTcpReassembly = disableTcpReasm
+
+		case "print-out-bad-message":
+			cfg.DebugSettings.PrintOutBadMessage = printOutBadMessage
 
 		case "wf":
 			cfg.PcapSettings.WriteFile = writeFile

--- a/src/cmd/heplify/main_test.go
+++ b/src/cmd/heplify/main_test.go
@@ -316,7 +316,7 @@ func TestConfigAndCLIParityForCriticalFields(t *testing.T) {
 		"hs", "nt", "skipverify", "keepalive", "tcpsendretries", "hin",
 		"l", "S", "e", "log-format", "hi", "hn", "hp", "fg", "fw", "rf",
 		"tcpassembly", "sipassembly", "ipfragment", "dd", "dim", "diip", "disip", "didip",
-		"fi", "di", "d", "log-payload", "disable-defrag", "disable-tcp-reasm",
+		"fi", "di", "d", "log-payload", "disable-defrag", "disable-tcp-reasm", "print-out-bad-message",
 		"wf", "rt", "zf", "rs", "lp", "eof-exit",
 		"prometheus", "api", "api-user", "api-pass", "api-tls", "api-cert", "api-key",
 		"script-file", "script-hep-filter",

--- a/src/cmd/heplify/version.go
+++ b/src/cmd/heplify/version.go
@@ -7,7 +7,7 @@ import (
 
 // Version is the application version. Updated by the release build process via scripts/update_version.sh.
 // Overridden at build time with -X main.Version=<ver> ldflags by GoReleaser and Makefile.
-var Version = "2.0.21"
+var Version = "2.0.22"
 
 // BuildDate is the UTC build timestamp. Set via -X main.BuildDate=<date> ldflags at build time.
 var BuildDate = "unknown"

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -67,6 +67,8 @@ type Config struct {
 	DebugSettings struct {
 		DisableTcpReassembly bool `json:"disable_tcp_reassembly" mapstructure:"disable_tcp_reassembly"`
 		DisableIPDefrag      bool `json:"disable_ip_defrag" mapstructure:"disable_ip_defrag"`
+		// PrintOutBadMessage: on HEP UDP "message too long", log HEP/payload dump (sizes always logged).
+		PrintOutBadMessage bool `json:"print_out_bad_message" mapstructure:"print_out_bad_message"`
 	} `json:"debug_settings" mapstructure:"debug_settings"`
 
 	ScriptSettings ScriptSettings `json:"script_settings" mapstructure:"script_settings"`

--- a/src/decoder/decoder.go
+++ b/src/decoder/decoder.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"net"
+	"time"
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/ip4defrag"
@@ -12,6 +13,10 @@ import (
 	"github.com/sipcapture/heplify/src/decoder/ip6defrag"
 	"github.com/sipcapture/heplify/src/decoder/ownlayers"
 )
+
+// IPFragmentFlushInterval is how long incomplete IP fragment flows are retained
+// before DiscardStaleFragments removes them (legacy heplify v1 used 1 minute).
+const IPFragmentFlushInterval = time.Minute
 
 // Packet represents a decoded network packet ready for HEP encoding
 type Packet struct {
@@ -588,6 +593,19 @@ func (p *Packet) GetPayload() string {
 func (d *Decoder) DisableDefrag() {
 	d.defrag4 = nil
 	d.defrag6 = nil
+}
+
+// DiscardStaleFragments removes incomplete IPv4/IPv6 fragment flows with no
+// activity since cutoff. Returns the number of flows discarded per protocol.
+// Incomplete flows are never emitted as HEP; this only limits memory growth.
+func (d *Decoder) DiscardStaleFragments(cutoff time.Time) (ipv4Flows, ipv6Flows int) {
+	if d.defrag4 != nil {
+		ipv4Flows = d.defrag4.DiscardOlderThan(cutoff)
+	}
+	if d.defrag6 != nil {
+		ipv6Flows = d.defrag6.DiscardOlderThan(cutoff)
+	}
+	return ipv4Flows, ipv6Flows
 }
 
 // boolToUint8 converts bool to uint8 (0 or 1)

--- a/src/decoder/defrag_flush_test.go
+++ b/src/decoder/defrag_flush_test.go
@@ -1,0 +1,26 @@
+package decoder
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/gopacket/layers"
+)
+
+func TestDiscardStaleFragments_disabled(t *testing.T) {
+	d := NewDecoder(layers.LinkTypeEthernet)
+	d.DisableDefrag()
+	v4, v6 := d.DiscardStaleFragments(time.Now())
+	if v4 != 0 || v6 != 0 {
+		t.Fatalf("expected 0,0 got %d,%d", v4, v6)
+	}
+}
+
+func TestDiscardStaleFragments_noStale(t *testing.T) {
+	d := NewDecoder(layers.LinkTypeEthernet)
+	cutoff := time.Now().Add(IPFragmentFlushInterval)
+	v4, v6 := d.DiscardStaleFragments(cutoff)
+	if v4 != 0 || v6 != 0 {
+		t.Fatalf("expected 0,0 got %d,%d", v4, v6)
+	}
+}

--- a/src/hep/payload.go
+++ b/src/hep/payload.go
@@ -1,0 +1,27 @@
+package hep
+
+import "encoding/binary"
+
+// PayloadBytes returns the raw bytes of HEP chunk 0x000f (Payload) if present.
+func PayloadBytes(packet []byte) []byte {
+	if len(packet) < 6 || string(packet[0:4]) != "HEP3" {
+		return nil
+	}
+	length := int(binary.BigEndian.Uint16(packet[4:6]))
+	if length > len(packet) {
+		length = len(packet)
+	}
+	offset := 6
+	for offset+6 <= length {
+		chunkLen := int(binary.BigEndian.Uint16(packet[offset+4 : offset+6]))
+		if chunkLen < 6 || offset+chunkLen > length {
+			return nil
+		}
+		chunkType := binary.BigEndian.Uint16(packet[offset+2 : offset+4])
+		if chunkType == ChunkPayload {
+			return packet[offset+6 : offset+chunkLen]
+		}
+		offset += chunkLen
+	}
+	return nil
+}

--- a/src/hep/payload_test.go
+++ b/src/hep/payload_test.go
@@ -1,0 +1,33 @@
+package hep
+
+import (
+	"net"
+	"testing"
+)
+
+func TestPayloadBytes(t *testing.T) {
+	msg := &Msg{
+		Version:   0x02,
+		Protocol:  0x11,
+		SrcIP:     net.ParseIP("10.0.0.1"),
+		DstIP:     net.ParseIP("10.0.0.2"),
+		SrcPort:   5060,
+		DstPort:   5060,
+		Tsec:      1,
+		Tmsec:     2,
+		ProtoType: 1,
+		NodeID:    1,
+		Payload:   []byte("INVITE sip:test SIP/2.0\r\n"),
+	}
+	pkt := Encode(msg)
+	got := PayloadBytes(pkt)
+	if string(got) != string(msg.Payload) {
+		t.Fatalf("payload: got %q want %q", got, msg.Payload)
+	}
+}
+
+func TestPayloadBytes_invalid(t *testing.T) {
+	if PayloadBytes([]byte("HEP2")) != nil {
+		t.Fatal("expected nil for invalid packet")
+	}
+}

--- a/src/sniffer/sniffer.go
+++ b/src/sniffer/sniffer.go
@@ -441,6 +441,24 @@ func (s *Sniffer) processPackets(source PacketSource, socket config.SocketSettin
 	// IP defragmentation: enabled by default, disabled via disable_ip_defrag.
 	if s.cfg.DebugSettings.DisableIPDefrag {
 		dec.DisableDefrag()
+	} else {
+		// Drop stale incomplete fragment flows (legacy heplify v1: every 1 minute).
+		go func() {
+			interval := decoder.IPFragmentFlushInterval
+			ticker := time.NewTicker(interval)
+			defer ticker.Stop()
+			for range ticker.C {
+				cutoff := time.Now().Add(-interval)
+				v4, v6 := dec.DiscardStaleFragments(cutoff)
+				if (v4 > 0 || v6 > 0) && s.debug.defrag {
+					log.Debug().
+						Int("ipv4_flows", v4).
+						Int("ipv6_flows", v6).
+						Dur("max_age", interval).
+						Msg("[defrag] discarded stale incomplete IP fragment flows")
+				}
+			}
+		}()
 	}
 
 	// TCP reassembly: enabled by default, disabled via disable_tcp_reassembly.

--- a/src/transport/hep_write_error.go
+++ b/src/transport/hep_write_error.go
@@ -1,0 +1,75 @@
+package transport
+
+import (
+	"encoding/hex"
+	"errors"
+	"strings"
+	"syscall"
+
+	"github.com/rs/zerolog"
+	"github.com/sipcapture/heplify/src/hep"
+)
+
+func isMessageTooLong(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, syscall.EMSGSIZE) {
+		return true
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "message too long")
+}
+
+func enrichMessageTooLongLog(ev *zerolog.Event, hepPacket []byte, wireBytes int, printBody bool) *zerolog.Event {
+	payload := hep.PayloadBytes(hepPacket)
+	ev = ev.Int("hep_bytes", len(hepPacket)).
+		Int("wire_bytes", wireBytes).
+		Int("hep_payload_bytes", len(payload))
+	if !printBody {
+		return ev
+	}
+	const maxHex = 512
+	const maxText = 8192
+	if len(payload) > 0 {
+		ev = ev.Str("hep_payload_hex", hexEncodeLimit(payload, maxHex))
+		if printableASCII(payload) {
+			ev = ev.Str("hep_payload", stringLimit(payload, maxText))
+		}
+	}
+	if len(hepPacket) > 0 {
+		ev = ev.Str("hep_packet_hex", hexEncodeLimit(hepPacket, maxHex))
+	}
+	return ev
+}
+
+func hexEncodeLimit(b []byte, max int) string {
+	if len(b) == 0 {
+		return ""
+	}
+	if len(b) > max {
+		b = b[:max]
+	}
+	return hex.EncodeToString(b)
+}
+
+func stringLimit(b []byte, max int) string {
+	if len(b) > max {
+		b = b[:max]
+	}
+	return string(b)
+}
+
+func printableASCII(b []byte) bool {
+	if len(b) == 0 {
+		return false
+	}
+	for _, c := range b {
+		if c < 0x20 && c != '\r' && c != '\n' && c != '\t' {
+			return false
+		}
+		if c > 0x7e {
+			return false
+		}
+	}
+	return true
+}

--- a/src/transport/hep_write_error_test.go
+++ b/src/transport/hep_write_error_test.go
@@ -1,0 +1,42 @@
+package transport
+
+import (
+	"errors"
+	"net"
+	"syscall"
+	"testing"
+
+	"github.com/rs/zerolog/log"
+	"github.com/sipcapture/heplify/src/hep"
+)
+
+func TestIsMessageTooLong(t *testing.T) {
+	if !isMessageTooLong(syscall.EMSGSIZE) {
+		t.Fatal("expected EMSGSIZE")
+	}
+	if !isMessageTooLong(errors.New("write udp 1.2.3.4:1->5.6.7.8:9060: write: message too long")) {
+		t.Fatal("expected string match")
+	}
+	if isMessageTooLong(errors.New("connection refused")) {
+		t.Fatal("unexpected match")
+	}
+}
+
+func TestEnrichMessageTooLongLog_noPanic(t *testing.T) {
+	msg := &hep.Msg{
+		Version:   0x02,
+		Protocol:  0x11,
+		SrcIP:     net.ParseIP("10.0.0.1"),
+		DstIP:     net.ParseIP("10.0.0.2"),
+		SrcPort:   5060,
+		DstPort:   5060,
+		ProtoType: 1,
+		Payload:   []byte("INVITE sip:x SIP/2.0\r\n"),
+	}
+	pkt := hep.Encode(msg)
+	ev := log.Error()
+	_ = enrichMessageTooLongLog(ev, pkt, len(pkt), true)
+	if len(hep.PayloadBytes(pkt)) == 0 {
+		t.Fatal("expected payload bytes")
+	}
+}

--- a/src/transport/sender.go
+++ b/src/transport/sender.go
@@ -314,14 +314,17 @@ func (s *Sender) reconnectLoop(client *HEPClient, reason string) {
 	}
 }
 
-func (s *Sender) handleWriteError(client *HEPClient, failedConn net.Conn, err error) {
-	log.Error().
+func (s *Sender) handleWriteError(client *HEPClient, failedConn net.Conn, err error, hepPacket []byte, wireBytes int) {
+	ev := log.Error().
 		Str("component", "sender").
 		Str("transport", client.proto).
 		Str("addr", client.addr).
 		Str("reason", "write error").
-		Err(err).
-		Msg("Failed to send HEP")
+		Err(err)
+	if isMessageTooLong(err) {
+		ev = enrichMessageTooLongLog(ev, hepPacket, wireBytes, s.cfg.DebugSettings.PrintOutBadMessage)
+	}
+	ev.Msg("Failed to send HEP")
 	client.mu.Lock()
 	if client.conn == failedConn && client.conn != nil {
 		_ = client.conn.Close()
@@ -419,7 +422,7 @@ func (s *Sender) sendToGroup(msg []byte, failoverOnly bool) bool {
 
 		n, err := conn.Write(data)
 		if err != nil {
-			s.handleWriteError(client, conn, err)
+			s.handleWriteError(client, conn, err, msg, len(data))
 			if !sent {
 				s.bufferToFile(msg)
 			}
@@ -595,8 +598,12 @@ func (s *Sender) drainBuffer(client *HEPClient) {
 		_, err := conn.Write(msg)
 		client.mu.Unlock()
 		if err != nil {
-			log.Error().Str("component", "sender").Err(err).Str("reason", "buffer drain write").Msg("Failed to send buffered HEP")
-			s.handleWriteError(client, conn, err)
+			ev := log.Error().Str("component", "sender").Err(err).Str("reason", "buffer drain write")
+			if isMessageTooLong(err) {
+				ev = enrichMessageTooLongLog(ev, msg, len(msg), s.cfg.DebugSettings.PrintOutBadMessage)
+			}
+			ev.Msg("Failed to send buffered HEP")
+			s.handleWriteError(client, conn, err, msg, len(msg))
 			break
 		}
 		sentCount++

--- a/src/transport/sender_reconnect_test.go
+++ b/src/transport/sender_reconnect_test.go
@@ -245,7 +245,7 @@ func TestHandleWriteErrorDoesNotCloseNewConn(t *testing.T) {
 		reconnecting: true,
 	}
 
-	sender.handleWriteError(client, oldConn, errors.New("stale write error"))
+	sender.handleWriteError(client, oldConn, errors.New("stale write error"), nil, 0)
 
 	client.mu.Lock()
 	defer client.mu.Unlock()


### PR DESCRIPTION
## Summary

- **UDP `message too long` diagnostics**: when HEP send fails with `EMSGSIZE` / `message too long`, the sender now always logs `hep_bytes`, `wire_bytes` (after optional gzip), and `hep_payload_bytes` (SIP payload from HEP chunk `0x000f`).
- **`-print-out-bad-message`**: optional flag (and `debug_settings.print_out_bad_message` / `HEPLIFY_DEBUG_SETTINGS_PRINT_OUT_BAD_MESSAGE`) to dump `hep_payload_hex`, printable `hep_payload`, and a short `hep_packet_hex` prefix for troubleshooting oversized HEP over UDP.
- **Stale IP fragment cleanup**: restores legacy heplify v1 behaviour — every minute, incomplete IPv4/IPv6 fragment flows older than 1 minute are discarded via `DiscardOlderThan`. This only frees memory; incomplete fragments are never sent as HEP.
- **Version**: bump to **2.0.22**.

## Context

Large SIP messages encapsulated in a single HEP3 UDP datagram can exceed the path MTU (~1500 bytes) and fail with `write: message too long` even when the SIP body is only a few KB. TCP transport avoids this. The new logging helps operators confirm actual HEP/payload sizes when the error occurs.

## Test plan

- [x] `go test ./...`
- [x] Deploy with `-nt udp` and `-print-out-bad-message`; confirm ERR lines include `hep_bytes` / `hep_payload_bytes` on failure
- [x] Optional: `-d defrag` and verify `[defrag] discarded stale incomplete IP fragment flows` when fragment loss occurs
- [x] Confirm `-disable-defrag` disables the periodic flush goroutine