### PR TITLE
fix: TCP SIP HEP timestamp ordering (#342)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **TCP SIP HEP ordering ([#342](https://github.com/sipcapture/heplify/issues/342))**: multiple SIP messages from one TCP capture timestamp receive incrementing HEP `Tmsec` values so Homer preserves wire order.
+
 ## [2.0.22] - 2026-05-19
 
 ### Added

--- a/src/cmd/heplify/version.go
+++ b/src/cmd/heplify/version.go
@@ -7,7 +7,7 @@ import (
 
 // Version is the application version. Updated by the release build process via scripts/update_version.sh.
 // Overridden at build time with -X main.Version=<ver> ldflags by GoReleaser and Makefile.
-var Version = "2.0.22"
+var Version = "2.0.23"
 
 // BuildDate is the UTC build timestamp. Set via -X main.BuildDate=<date> ldflags at build time.
 var BuildDate = "unknown"

--- a/src/decoder/tcpassembly.go
+++ b/src/decoder/tcpassembly.go
@@ -66,6 +66,9 @@ type sipStream struct {
 	cb             SIPCallback
 	buf            []byte
 	ts             time.Time
+	// tsSeq assigns distinct HEP Tmsec values when multiple SIP messages share
+	// one TCP capture timestamp (same segment). Homer sorts by (Tsec, Tmsec).
+	tsSeq uint32
 }
 
 func (s *sipStream) Reassembled(reassemblies []tcpassembly.Reassembly) {
@@ -79,7 +82,7 @@ func (s *sipStream) Reassembled(reassemblies []tcpassembly.Reassembly) {
 			// immediately instead of waiting for the connection to be torn
 			// down and a new SYN to be captured.
 			s.buf = s.buf[:0]
-			s.ts = time.Time{}
+			s.clearTimestamp()
 			// fall through ↓
 		}
 		if len(r.Bytes) == 0 {
@@ -87,6 +90,7 @@ func (s *sipStream) Reassembled(reassemblies []tcpassembly.Reassembly) {
 		}
 		if s.ts.IsZero() {
 			s.ts = r.Seen
+			s.tsSeq = 0
 		}
 		s.buf = append(s.buf, r.Bytes...)
 	}
@@ -106,7 +110,7 @@ func (s *sipStream) process() {
 				return // wait for more data
 			}
 			s.buf = s.buf[end+4:]
-			s.ts = time.Time{}
+			s.clearTimestamp()
 			continue
 		}
 
@@ -125,7 +129,7 @@ func (s *sipStream) process() {
 			// Use the full buffer length as a safe approximation; the next
 			// iteration will restart cleanly if there is trailing data.
 			s.buf = s.buf[:0]
-			s.ts = time.Time{}
+			s.clearTimestamp()
 			return
 		}
 
@@ -137,7 +141,7 @@ func (s *sipStream) process() {
 			// Not SIP or corrupted — safety valve: drop if buffer is huge.
 			if len(s.buf) > 1<<20 {
 				s.buf = s.buf[:0]
-				s.ts = time.Time{}
+				s.clearTimestamp()
 			}
 			return
 		}
@@ -148,13 +152,30 @@ func (s *sipStream) process() {
 		}
 		s.buf = s.buf[len(payload):]
 		// When the buffer is empty, clear the timestamp so the next
-		// Reassembled() call picks up a fresh r.Seen for the next message.
-		// Do NOT clear it while data still remains — consecutive SIP messages
-		// inside the same TCP segment share the segment's capture timestamp.
+		// Reassembled() call picks up a fresh r.Seen for the next segment.
+		// While data remains, consecutive SIP messages keep the same capture
+		// second but receive incrementing Tmsec via tsSeq (issue #342).
 		if len(s.buf) == 0 {
-			s.ts = time.Time{}
+			s.clearTimestamp()
 		}
 	}
+}
+
+func (s *sipStream) clearTimestamp() {
+	s.ts = time.Time{}
+	s.tsSeq = 0
+}
+
+// hepTimestampFromCapture maps a capture time and sub-message sequence to HEP fields.
+func hepTimestampFromCapture(ts time.Time, seq uint32) (tsec, tmsec uint32) {
+	tsec = uint32(ts.Unix())
+	us := uint64(ts.Nanosecond()/1000) + uint64(seq)
+	if us >= 1_000_000 {
+		tsec += uint32(us / 1_000_000)
+		tmsec = uint32(us % 1_000_000)
+		return tsec, tmsec
+	}
+	return tsec, uint32(us)
 }
 
 func (s *sipStream) buildPacket(payload []byte) *Packet {
@@ -193,8 +214,8 @@ func (s *sipStream) buildPacket(payload []byte) *Packet {
 	}
 
 	if !s.ts.IsZero() {
-		pkt.Tsec = uint32(s.ts.Unix())
-		pkt.Tmsec = uint32(s.ts.Nanosecond() / 1000)
+		pkt.Tsec, pkt.Tmsec = hepTimestampFromCapture(s.ts, s.tsSeq)
+		s.tsSeq++
 	}
 	return pkt
 }

--- a/src/decoder/tcpassembly_timestamp_test.go
+++ b/src/decoder/tcpassembly_timestamp_test.go
@@ -1,0 +1,85 @@
+package decoder
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"github.com/google/gopacket/tcpassembly"
+)
+
+func TestHepTimestampFromCapture_sequence(t *testing.T) {
+	ts := time.Unix(1_700_000_000, 818142*1000)
+	tsec, tmsec := hepTimestampFromCapture(ts, 0)
+	if tsec != uint32(ts.Unix()) || tmsec != 818142 {
+		t.Fatalf("seq 0: got tsec=%d tmsec=%d", tsec, tmsec)
+	}
+	tsec, tmsec = hepTimestampFromCapture(ts, 1)
+	if tmsec != 818143 {
+		t.Fatalf("seq 1: got tmsec=%d want 818143", tmsec)
+	}
+}
+
+func TestHepTimestampFromCapture_overflowSecond(t *testing.T) {
+	ts := time.Unix(100, 999_999*1000)
+	tsec, tmsec := hepTimestampFromCapture(ts, 1)
+	if tsec != 101 || tmsec != 0 {
+		t.Fatalf("overflow: got tsec=%d tmsec=%d want 101/0", tsec, tmsec)
+	}
+}
+
+func TestTCPSIPDistinctTmsecPerMessage(t *testing.T) {
+	msg1 := []byte("INVITE sip:a@example.com SIP/2.0\r\nContent-Length: 0\r\n\r\n")
+	msg2 := []byte("ACK sip:a@example.com SIP/2.0\r\nContent-Length: 0\r\n\r\n")
+	combined := append(append([]byte{}, msg1...), msg2...)
+
+	var received []*Packet
+	cb := func(pkt *Packet) { received = append(received, pkt) }
+
+	s := &sipStream{
+		net:       gopacket.NewFlow(layers.EndpointIPv4, []byte{10, 0, 0, 1}, []byte{10, 0, 0, 2}),
+		transport: gopacket.NewFlow(0, []byte{0x13, 0xc4}, []byte{0x13, 0xc4}),
+		cb:        cb,
+		buf:       make([]byte, 0, 4096),
+	}
+
+	ts := time.Unix(1_778_592_875, 818142*1000)
+	s.Reassembled([]tcpassembly.Reassembly{{Bytes: combined, Seen: ts}})
+
+	if len(received) != 2 {
+		t.Fatalf("expected 2 SIP packets, got %d", len(received))
+	}
+	if received[0].Tsec != uint32(ts.Unix()) || received[0].Tmsec != 818142 {
+		t.Fatalf("msg0: tsec=%d tmsec=%d", received[0].Tsec, received[0].Tmsec)
+	}
+	if received[1].Tsec != uint32(ts.Unix()) || received[1].Tmsec != 818143 {
+		t.Fatalf("msg1: tsec=%d tmsec=%d want tmsec 818143", received[1].Tsec, received[1].Tmsec)
+	}
+}
+
+func TestTCPSIPDistinctTmsecAcrossSegments(t *testing.T) {
+	msg := []byte("SIP/2.0 200 OK\r\nContent-Length: 0\r\n\r\n")
+
+	var received []*Packet
+	cb := func(pkt *Packet) { received = append(received, pkt) }
+
+	s := &sipStream{
+		net:       gopacket.NewFlow(layers.EndpointIPv4, []byte{10, 0, 0, 1}, []byte{10, 0, 0, 2}),
+		transport: gopacket.NewFlow(0, []byte{0x13, 0xc4}, []byte{0x13, 0xc4}),
+		cb:        cb,
+		buf:       make([]byte, 0, 4096),
+	}
+
+	ts1 := time.Unix(100, 100*1000)
+	s.Reassembled([]tcpassembly.Reassembly{{Bytes: msg, Seen: ts1}})
+	ts2 := time.Unix(100, 200*1000)
+	s.Reassembled([]tcpassembly.Reassembly{{Bytes: msg, Seen: ts2}})
+
+	if len(received) != 2 {
+		t.Fatalf("expected 2 packets, got %d", len(received))
+	}
+	if received[0].Tmsec != 100 || received[1].Tmsec != 200 {
+		t.Fatalf("tmsec: %d, %d", received[0].Tmsec, received[1].Tmsec)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes [issue #342](https://github.com/sipcapture/heplify/issues/342): SIP over TCP appeared out of order in Homer while wire order was correct.

When several SIP messages are delivered from one TCP capture timestamp (multiple messages in the same segment or reassembly batch), heplify previously wrote the same HEP `Tsec`/`Tmsec` for each message. Homer sorts by timestamp, so the call flow looked shuffled.

This change keeps the capture second and base microsecond from the TCP segment, and adds a per-stream `tsSeq` counter so each emitted SIP message gets `Tmsec = base + 0`, `base + 1`, … (with carry into `Tsec` if needed).

## Changes

- `sipStream.tsSeq` + `hepTimestampFromCapture()` in `tcpassembly.go`
- `clearTimestamp()` resets both `ts` and `tsSeq` on gaps / buffer flush
- Unit tests for increment and separate segments

## Version

Bump to **2.0.23**.

## Test plan

- [x] `go test ./...`
- [x] Reproduce reporter scenario on v2.0.23: TCP SIP call flow in Homer matches wire order
- [x] Confirm UDP capture unchanged
- [x] Optional: `-fw 1` still recommended if fanout reordering is suspected in addition to this fix

Fixes #342