### PR TITLE
Potential fix for code scanning alert no. 6: Incorrect conversion between integer types

### DIFF
--- a/src/script/engine.go
+++ b/src/script/engine.go
@@ -290,13 +290,13 @@ func (e *Engine) setHEPField(L *lua.LState) int {
 	case "SrcIP":
 		e.pkt.SrcIP = net.ParseIP(value)
 	case "SrcPort":
-		if i, err := strconv.Atoi(value); err == nil {
+		if i, err := strconv.ParseUint(value, 10, 16); err == nil {
 			e.pkt.SrcPort = uint16(i)
 		}
 	case "DstIP":
 		e.pkt.DstIP = net.ParseIP(value)
 	case "DstPort":
-		if i, err := strconv.Atoi(value); err == nil {
+		if i, err := strconv.ParseUint(value, 10, 16); err == nil {
 			e.pkt.DstPort = uint16(i)
 		}
 	case "CID":


### PR DESCRIPTION
Potential fix for [https://github.com/sipcapture/heplify/security/code-scanning/6](https://github.com/sipcapture/heplify/security/code-scanning/6)

Use parsing that enforces the target bit width at parse-time instead of parsing to `int` and narrowing later.

Best fix here (minimal behavior change, addresses both flagged variants):  
- In `src/script/engine.go`, inside `setHEPField`, replace `strconv.Atoi(value)` + `uint16(i)` in `SrcPort` and `DstPort` cases with `strconv.ParseUint(value, 10, 16)`, then cast to `uint16`.
- This guarantees only values in `0..65535` are accepted and avoids architecture-dependent `int` narrowing.
- No new imports are needed (`strconv` is already imported).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
