### PR TITLE
Potential fix for code scanning alert no. 4: Incorrect conversion between integer types

### DIFF
--- a/src/script/engine.go
+++ b/src/script/engine.go
@@ -284,7 +284,7 @@ func (e *Engine) setHEPField(L *lua.LState) int {
 
 	switch field {
 	case "ProtoType":
-		if i, err := strconv.Atoi(value); err == nil {
+		if i, err := strconv.ParseUint(value, 10, 8); err == nil {
 			e.pkt.ProtoType = byte(i)
 		}
 	case "SrcIP":


### PR DESCRIPTION
Potential fix for [https://github.com/sipcapture/heplify/security/code-scanning/4](https://github.com/sipcapture/heplify/security/code-scanning/4)

Use parsing with the correct bit size for the target type to avoid unsafe narrowing conversions.  
Best fix: in `src/script/engine.go`, inside `setHEPField` for case `"ProtoType"`, replace `strconv.Atoi` with `strconv.ParseUint(value, 10, 8)` and assign the parsed value to `byte`. This enforces the `0..255` range during parsing and avoids architecture-dependent `int` conversion issues. No new imports are required because `strconv` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
