### PR TITLE
Potential fix for code scanning alert no. 3: Incorrect conversion between integer types

### DIFF
--- a/src/cmd/heplify/main.go
+++ b/src/cmd/heplify/main.go
@@ -716,25 +716,25 @@ func parseCaptureMode(mode string) []string {
 
 func parsePortRange(pr string) (uint16, uint16, error) {
 	parts := strings.Split(pr, "-")
-	minInt, maxInt := 5060, 5090
+	minPort, maxPort := uint16(5060), uint16(5090)
 	if len(parts) >= 1 {
-		parsed, err := strconv.Atoi(parts[0])
+		parsed, err := strconv.ParseUint(parts[0], 10, 16)
 		if err != nil {
 			return 0, 0, fmt.Errorf("invalid min port: %w", err)
 		}
-		minInt = parsed
+		minPort = uint16(parsed)
 	}
 	if len(parts) >= 2 {
-		parsed, err := strconv.Atoi(parts[1])
+		parsed, err := strconv.ParseUint(parts[1], 10, 16)
 		if err != nil {
 			return 0, 0, fmt.Errorf("invalid max port: %w", err)
 		}
-		maxInt = parsed
+		maxPort = uint16(parsed)
 	}
-	if minInt < 1 || maxInt > 65535 || minInt > maxInt {
-		return 0, 0, fmt.Errorf("port range out of bounds: %d-%d", minInt, maxInt)
+	if minPort < 1 || minPort > maxPort {
+		return 0, 0, fmt.Errorf("port range out of bounds: %d-%d", minPort, maxPort)
 	}
-	return uint16(minInt), uint16(maxInt), nil
+	return minPort, maxPort, nil
 }
 
 func parseCSV(s string) []string {


### PR DESCRIPTION
Potential fix for [https://github.com/sipcapture/heplify/security/code-scanning/3](https://github.com/sipcapture/heplify/security/code-scanning/3)

Use fixed-width parsing for ports instead of `strconv.Atoi`. In `src/cmd/heplify/main.go`, update `parsePortRange` to:

- Parse each provided bound with `strconv.ParseUint(..., 10, 16)`.
- Keep default values as `uint16` (`5060`, `5090`) to avoid narrowing casts.
- Validate ordering with `minPort > maxPort`.
- Return `minPort, maxPort` directly.

This preserves behavior (same defaults, same accepted range semantics) while removing architecture-dependent `int` parsing and unsafe-looking downcasts that trigger CodeQL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
