### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
       - main
       - master
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/sipcapture/heplify/security/code-scanning/2](https://github.com/sipcapture/heplify/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root in `.github/workflows/ci.yml`, directly under `on:` (or before `jobs:`), setting least privilege for all jobs unless overridden. For this workflow, the best non-breaking minimal setting is:

- `contents: read`

This preserves existing functionality (checkout and read access to repo content) while preventing unnecessary write access. No imports, methods, or dependencies are involved since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
